### PR TITLE
102 Crash Course: Fix a few issues in Lesson 4. Management utilities

### DIFF
--- a/102-cbdb-crash-course/README.md
+++ b/102-cbdb-crash-course/README.md
@@ -112,14 +112,16 @@ In summary, management utilities are command-line programs and scripts used by D
 
 - `gpstop`: stops database cluster.
 - `gpstart`: starts database cluster.
+- `gpstate`: shows the status of a running cluster.
 - `psql`: a command-line client.
 - `gpconfig`: shows or changes configuration parameters.
 - `gpdeletesystem`: deletes a cluster.
 - `pg_dump`, `gpbackup`, `gprestore`: performs backup and restore operations.
-- `gpinitstanby`, `gpactivatestandby`: manages the standby master instance.
+- `gpinitstandby`, `gpactivatestandby`: manages the standby master instance.
 - `gprecoverseg`: recovers segment.
 - `gpfdist`, `gpload`: operates with external tables.
-- `gpssh`, `gpscp`, `gpssh-exkeys`: for cluster navigation.
+- `gpssh`, `gpssh-exkeys`: for cluster navigation.
+- `gpsync`: rsync files to multiple hosts at once.
 - Logging - all utilities write log files under `~/gpAdminLogs/` - one file per day
 
 **Exercise**


### PR DESCRIPTION
Address the following issues with the list of common utilties:

* Add `gpstate` as it is an extremely common utility
* Fix typo `gpinitstanby` --> `gpinitstandby`
* The utility `gpscp` has been replaced by `gpsync`

FYI: I noticed these issues by attempting to list all utilities referenced in the 102-cbdb-crash-course --> Lesson 4. Management utilities. The typo was readily apparent as well as the renamed utility. I felt `gpstate` should have been listed as well.