### PR TITLE
Change the CentOS 7 repo to vault.centos.org

### DIFF
--- a/000-cbdb-sandbox/Dockerfile.RELEASE.centos7
+++ b/000-cbdb-sandbox/Dockerfile.RELEASE.centos7
@@ -16,12 +16,25 @@ rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 COPY ./configs/* /tmp/
 
+RUN     sed -i \
+        -e 's/^mirrorlist/#mirrorlist/' \
+        -e 's/^#baseurl/baseurl/' \
+        -e 's/mirror\.centos\.org/vault.centos.org/' \
+        /etc/yum.repos.d/*.repo
+
+RUN     yum clean all; yum makecache \
+        && yum install -y centos-release-scl-rh epel-release
+
+RUN     sed -i \
+        -e 's/^mirrorlist/#mirrorlist/' \
+        -e 's/^#baseurl/baseurl/' \
+        -e 's/mirror\.centos\.org/vault.centos.org/' \
+        /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
+
 RUN     echo root:cbdb@123 | chpasswd \
-        && yum install -y epel-release \
         && yum install -y initscripts unzip which tar less net-tools util-linux-ng passwd openssh-clients openssh-server perl ed m4 sudo rsync git wget \
-        && yum install -y apr-devel bison bzip2-devel cmake3 flex gcc gcc-c++ go krb5-devel libcurl-devel libevent-devel libkadm5 libxml2-devel libyaml-devel libzstd-devel openssl-devel perl-ExtUtils-Embed readline-devel xerces-c-devel zlib-devel \
-        && yum install -y postgresql postgresql-devel \
-        && yum install -y centos-release-scl scl-utils \
+	&& yum install -y apr-devel bison bzip2-devel flex go krb5-devel libcurl-devel libevent-devel libkadm5 libxml2-devel libyaml-devel libzstd-devel openssl-devel perl-ExtUtils-Embed readline-devel xerces-c-devel zlib-devel \
+        && yum install -y scl-utils \
         && yum install -y devtoolset-10
 
 RUN     cat /tmp/90-cbdb-sysctl.conf >> /etc/sysctl.conf \
@@ -53,20 +66,11 @@ RUN     cat /tmp/90-cbdb-sysctl.conf >> /etc/sysctl.conf \
 RUN     yum install -y python3-devel python3-pip; yum clean all
 
 RUN     cd /tmp/ \
-        && unzip -d /tmp /tmp/cloudberrydb-${CODEBASE_VERSION_VAR}.zip \
-        && cd /tmp/cloudberrydb-${CODEBASE_VERSION_VAR} \
-        && if [ -f python-dependencies.txt ]; then \
-              pip3 install -i ${PIP_INDEX_URL_VAR} -r python-dependencies.txt; \
-           elif [ -f readmes/python-dependencies.txt ]; then \
-              pip3 install -i ${PIP_INDEX_URL_VAR} -r readmes/python-dependencies.txt; \
-           else \
-             echo "File does not exist, skipping additional commands"; \
-             exit 2; \
-           fi
+	&& unzip -d /tmp /tmp/cloudberrydb-${CODEBASE_VERSION_VAR}.zip
 
 RUN     cd /tmp/cloudberrydb-${CODEBASE_VERSION_VAR} \
         && source scl_source enable devtoolset-10 \
-        && ./configure --with-perl --with-python --with-libxml --with-gssapi --prefix=/usr/local/cloudberry-db
+	&& ./configure --with-perl --with-python --with-libxml --with-gssapi --prefix=/usr/local/cloudberry-db --with-pythonsrc-ext
 
 RUN     cd /tmp/cloudberrydb-${CODEBASE_VERSION_VAR} \
         && source scl_source enable devtoolset-10 \

--- a/000-cbdb-sandbox/Dockerfile.RELEASE.centos7
+++ b/000-cbdb-sandbox/Dockerfile.RELEASE.centos7
@@ -33,7 +33,7 @@ RUN     sed -i \
 
 RUN     echo root:cbdb@123 | chpasswd \
         && yum install -y initscripts unzip which tar less net-tools util-linux-ng passwd openssh-clients openssh-server perl ed m4 sudo rsync git wget \
-	&& yum install -y apr-devel bison bzip2-devel flex go krb5-devel libcurl-devel libevent-devel libkadm5 libxml2-devel libyaml-devel libzstd-devel openssl-devel perl-ExtUtils-Embed readline-devel xerces-c-devel zlib-devel \
+        && yum install -y apr-devel bison bzip2-devel flex go krb5-devel libcurl-devel libevent-devel libkadm5 libxml2-devel libyaml-devel libzstd-devel openssl-devel perl-ExtUtils-Embed readline-devel xerces-c-devel zlib-devel \
         && yum install -y scl-utils \
         && yum install -y devtoolset-10
 
@@ -66,11 +66,11 @@ RUN     cat /tmp/90-cbdb-sysctl.conf >> /etc/sysctl.conf \
 RUN     yum install -y python3-devel python3-pip; yum clean all
 
 RUN     cd /tmp/ \
-	&& unzip -d /tmp /tmp/cloudberrydb-${CODEBASE_VERSION_VAR}.zip
+        && unzip -d /tmp /tmp/cloudberrydb-${CODEBASE_VERSION_VAR}.zip
 
 RUN     cd /tmp/cloudberrydb-${CODEBASE_VERSION_VAR} \
         && source scl_source enable devtoolset-10 \
-	&& ./configure --with-perl --with-python --with-libxml --with-gssapi --prefix=/usr/local/cloudberry-db --with-pythonsrc-ext
+        && ./configure --with-perl --with-python --with-libxml --with-gssapi --prefix=/usr/local/cloudberry-db --with-pythonsrc-ext
 
 RUN     cd /tmp/cloudberrydb-${CODEBASE_VERSION_VAR} \
         && source scl_source enable devtoolset-10 \

--- a/000-cbdb-sandbox/README.md
+++ b/000-cbdb-sandbox/README.md
@@ -21,6 +21,9 @@ Make sure that your environment meets the following requirements:
 
 This section introduces two methods to set up the Docker container. The container will host a CBDB single-node cluster intialized with one coordinator and three primary and mirror segments. Both x86 and ARM CPUs (including Apple chips) are supported.
 
+> [!CAUTION]
+> The CentOS Linux 7 the reached end of life (EOL) on June 30, 2024. The software source mirror (vault) only supports x86_64, the `altarch` source (like ARM) has been deprecated. So you cannot run the CentOS 7 sandbox on your macBook with M1/2. 
+
 - Method 1 - Compile with the source code of the latest Cloudberry Database (released in [Cloudberry Database Release Page](https://github.com/cloudberrydb/cloudberrydb/releases)). The base OS will use CentOS 7.9 Docker container.
 - Method 2 - Compile with the latest Cloudberry Database [main](https://github.com/cloudberrydb/cloudberrydb/tree/main) branch. The base OS will use Rocky Linux 9 Docker container.
 


### PR DESCRIPTION
## Change logs

The CentOS Linux 7 reached the end of life (EOL) on June 30, 2024. For the sandbox based on CentOS 7, we cannot get any update using mirrors.centos.org. So change the mirror to vault.centos.org

Now it can work well on x86_64 cpu, but cannot work on ARM and other CPUs.

## Contributor's checklist

Here are some reminders before you submit your pull request:

* Make sure that your Pull Request has a clear title and commit message. You can take the [Git commit template](https://github.com/cloudberrydb/cloudberrydb/blob/main/.gitmessage) as a reference.
* Sign the Contributor License Agreement as prompted for your first-time contribution (*One-time setup*).
* Learn the [code contribution](https://cloudberrydb.org/contribute/code) and [doc contribution](https://cloudberrydb.org/contribute/doc) guides for better collaboration.
* List your communications in the [GitHub Issues](https://github.com/cloudberrydb/cloudberrydb-site/issues) or [Discussions](https://github.com/orgs/cloudberrydb/discussions) (if has or needed).
* Feel free to ask for other people to help review and approve.
